### PR TITLE
Xml declaration

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Sorts the Compile and Reference items in ItemGroups of your *.csproj and *.vbpro
   3. sortprojectitems /r
 
 It will recursively find all *.csproj and *.vbproj files in the current directory and all subdirectories and sort all MSBuild ItemGroups. It will also consolidate ItemGroups by kind and remove empty ItemGroups.
+The /x argument will omit XML declarations from output files.
 
 Note: Visual Studio normally tries to preserve sorting when modifying the project, however:
   * several operations such as Rename in Solution Explorer and Include in Project for resource files are known to break the order.

--- a/SortProjectItems/SortProjectItems.cs
+++ b/SortProjectItems/SortProjectItems.cs
@@ -263,7 +263,7 @@ SortProjectItems.exe /r
         var original = itemGroup.Elements().ToArray();
         var sorted = original
             .OrderBy(i => i.Name.LocalName)
-            .ThenBy(i => (i.Attribute("Include") ?? i.Attribute("Remove")).Value)
+            .ThenBy(i => (i.Attribute("Include") ?? i.Attribute("Remove") ?? i.Attribute("Update")).Value)
             .ToArray();
 
         for (int i = 0; i < original.Length; i++)


### PR DESCRIPTION
The current behaviour of the tool inserts an XML declaration `<?xml version="1.0" encoding="utf-8"?>` to the top of every file, which is appropriate for old csproj files, but which isn't appropriate for SDK-style projects.

This PR resolves that by adding an optional argument to omit XML declarations:
* Output if the /x argument isn't supplied is unchanged.
* The `StreamWriter` used for writing the XML is replaced with an `XmlWriter` that takes the `OmitXmlDeclaration` argument.
* Argument parsing is updated with an attempt to maintain consistency with other projects in the repository/solution.

I also included an additional fix that addresses a crash in the tool if it encounters elements with no `Include` or `Remove` attribute, e.g.
```xml
<EmbeddedResource Update="resource.resx" />
```